### PR TITLE
feat: center one page PDFs; PLA-6133

### DIFF
--- a/Classes/ComPspdfkitViewProxy.h
+++ b/Classes/ComPspdfkitViewProxy.h
@@ -30,6 +30,9 @@
 /// Change view mode argument 1 = integer, argument 2 = animated. (optional, defaults to YES)
 - (void)setViewMode:(id)args;
 
+/// Change the page mode (argument 1 = integer)
+- (void)setPageMode:(id)args;
+
 /// Open search.
 - (void)searchForString:(id)args;
 

--- a/Classes/ComPspdfkitViewProxy.m
+++ b/Classes/ComPspdfkitViewProxy.m
@@ -127,6 +127,11 @@ _Pragma("clang diagnostic pop") \
     [[[self pdfView] controllerProxy] setViewMode:args];
 }
 
+- (void)setPageMode:(id)args {
+    ENSURE_UI_THREAD(setPageMode, args);
+    [[[self pdfView] controllerProxy] setPageMode:args];
+}
+
 - (void)searchForString:(id)args {
     ENSURE_UI_THREAD(searchForString, args);
     [[[self pdfView] controllerProxy] searchForString:args];

--- a/Classes/TIPSPDFViewControllerProxy.h
+++ b/Classes/TIPSPDFViewControllerProxy.h
@@ -37,6 +37,9 @@
 /// change view mode argument 1 = integer, argument 2 = animated. (optional, defaults to YES)
 - (void)setViewMode:(id)args;
 
+/// Change the page mode (argument 1 = integer)
+- (void)setPageMode:(id)args;
+
 /// Opens the PSPDFSearchViewController with the searchString.
 - (void)searchForString:(id)args;
 

--- a/Classes/TIPSPDFViewControllerProxy.m
+++ b/Classes/TIPSPDFViewControllerProxy.m
@@ -268,6 +268,16 @@ void (^tipspdf_targetActionBlock(id target, SEL action))(id) {
     [self.controller setViewMode:viewModeValue animated:animated];
 }
 
+- (void)setPageMode:(id)args {
+    ENSURE_UI_THREAD(setPageMode, args);
+
+    PSCLog(@"setPageMode: %@", args);
+    NSUInteger pageModeValue = [PSPDFUtils intValue:args onPosition:0];
+    [self.controller updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
+        builder.pageMode = pageModeValue;
+    }];
+}
+
 - (void)searchForString:(id)args {
     ENSURE_UI_THREAD(searchForString, args);
 

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 11.3.2
+version: 11.3.2.1
 description: PSPDFKit Annotate Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com


### PR DESCRIPTION
https://pitcher-ag.atlassian.net/browse/PLA-6133

### 📖 Description

This pull request exposes `setPageMode` method on the PSPDFKit view proxy, to enable centering one page PDFs from the app perspective, no matter the PDF reading mode chosen by the user.

### 📖 Screenshot

<img width="1191" alt="Sonicoil_PDF_CDC_Percentile_Chart_OnePagePDFCentered" src="https://user-images.githubusercontent.com/2694531/179725172-773896c9-f5b1-48e3-ba0d-e0eebbda8ba3.png">

