### PR TITLE
fix: workaround for the `PSPDFKit` printing issue for files with `/` char in the title; PLA-13293

### DIFF
--- a/Classes/ComPspdfkitView.m
+++ b/Classes/ComPspdfkitView.m
@@ -48,15 +48,20 @@
             PSPDFDocumentSharingConfiguration *emailCustomConfiguration = [self getSharingConfigurationForDestination:PSPDFDocumentSharingDestinationEmail];
             PSPDFDocumentSharingConfiguration *printCustomConfiguration = [self getSharingConfigurationForDestination:PSPDFDocumentSharingDestinationPrint];
             builder.sharingConfigurations = @[emailCustomConfiguration, printCustomConfiguration];
+            builder.allowToolbarTitleChange = NO;
             builder.searchResultZoomScale = 1.0; // To disable the logic to automatically zoom to selected search result
             
             [builder overrideClass:PSPDFDocumentSharingViewController.class withClass:SharingViewController.class];
         }];
         TIPSPDFViewController *pdfController = [[TIPSPDFViewController alloc] initWithDocument:pdfDocument configuration:configuration];
 
+        NSDictionary *documentOptions = [self.proxy valueForKey:@"documentOptions"];
+        NSString *documentTitle = [documentOptions valueForKey:@"title"];
         [PSPDFUtils applyOptions:options onObject:pdfController];
-        [PSPDFUtils applyOptions:[self.proxy valueForKey:@"documentOptions"] onObject:pdfDocument];
-
+        [PSPDFUtils applyOptions:documentOptions onObject:pdfDocument];
+        pdfController.title = documentTitle;
+        pdfDocument.title = [documentTitle stringByReplacingOccurrencesOfString:@"/" withString:@""];
+        
         // default-hide close button
         if (![self.proxy valueForKey:@"options"][PROPERTY(leftBarButtonItems)]) {
             pdfController.navigationItem.leftBarButtonItems = @[];

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 11.3.2.1
+version: 12.0.3
 description: PSPDFKit Annotate Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com


### PR DESCRIPTION
https://pitcher-ag.atlassian.net/browse/PLA-13293

### 📖 Description

This pull request provides a workaround for the `PSPDFKit` printing issue for files with `/` char in the title.
The title passed to `PSPDFDocument` object is stripped from `/` chars, while the title of the view controller visible for the end user (`PSPDFViewController`) remains untouched.

### 📖 Recording - Before the fix:

https://user-images.githubusercontent.com/2694531/220924338-197a466d-8aaf-4d4a-a246-dfa07c725a45.mov

### 📖 Recording - Before after fix:

https://user-images.githubusercontent.com/2694531/220924366-67177f66-8c37-4a6f-902c-70f9293858fe.mov


