### PR TITLE
fix: some hotspots not working with build using iOS SDK 17; Upgrade PSPDFKit version to v13.3.2; CORE-4419 / CORE-4574

### DIFF
--- a/Classes/TIPSPDFViewControllerProxy.m
+++ b/Classes/TIPSPDFViewControllerProxy.m
@@ -428,7 +428,9 @@ _Pragma("clang diagnostic pop")
         if (linkAnnotation.URL) {
             eventDict[@"URL"] = linkAnnotation.URL;
             eventDict[@"siteLinkTarget"] = linkAnnotation.URL.absoluteString;
-        }else if (linkAnnotation.linkType == PSPDFLinkAnnotationPage) {
+        } else if (linkAnnotation.URLAction.invalidURLString != nil) {
+            eventDict[@"siteLinkTarget"] = linkAnnotation.URLAction.invalidURLString;
+        } else if (linkAnnotation.linkType == PSPDFLinkAnnotationPage) {
             // We don't forward all proxy types.
             if ([linkAnnotation.action respondsToSelector:@selector(pageIndex)]) {
                 eventDict[@"pageIndex"] = @(((PSPDFGoToAction *)linkAnnotation.action).pageIndex);

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 12.0.3
+version: 13.3.2
 description: PSPDFKit Annotate Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com


### PR DESCRIPTION
https://pitcher-ag.atlassian.net/browse/CORE-4419
https://pitcher-ag.atlassian.net/browse/CORE-4574

### 📖 Description

This pull request addresses the issue of some hotspots not working with build using iOS SDK 17 (hotspots like: launching other content or exiting the presentation). The fix required changes on PSPDFKit SDK, so this PR also upgrades to PSPDFKit v13.3.2, which includes new API: `invalidURLString` property on `URLAction`, as described in the official release notes: https://pspdfkit.com/changelog/ios/ (Z#108707).