### PR TITLE
fix: PDF embedded videos no longer working with iOS SDK 17; CORE-4926

### DIFF
--- a/Classes/TIPSPDFViewController.m
+++ b/Classes/TIPSPDFViewController.m
@@ -15,6 +15,8 @@
 #import "ComPspdfkitModule.h"
 #import <objc/runtime.h>
 
+NSString *const kTempAnnotationIdSuffix = @"_tempPitAnn";
+
 @interface PSPDFViewController (Internal)
 - (void)delegateDidShowController:(id)viewController embeddedInController:(id)controller options:(NSDictionary *)options animated:(BOOL)animated;
 - (BOOL)presentViewController:(UIViewController *)controller options:(nullable NSDictionary<NSString *, id> *)options animated:(BOOL)animated sender:(nullable id)sender completion:(nullable void (^)(void))completion;
@@ -49,6 +51,18 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - UIViewController
 
+- (void)loadView {
+    [super loadView];
+    
+    // NOTE: KK: 04.04.2024: Due to video link annotations no longer working on iOS SDK 17
+    // (due to Apple changing URL/NSURL parsing from the obsolete RFC 1738/1808 standard to RFC 3986)
+    // below we're dynamically replacing those video link annotations using the `URLAction.invalidURLString` of a given broken annotation
+    // (stripping out all the display options between `[` and `]` chars in the original URLs)
+    if (@available(iOS 17.0, *)) {
+        [self handleDynamicAnnotations];
+    }
+}
+
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
 
@@ -74,6 +88,109 @@
 // If we return YES here, UIWindow leaks our controller in the Titanium configuration.
 - (BOOL)canBecomeFirstResponder {
     return NO;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Dynamic Annotations
+
+- (void)handleDynamicAnnotations {
+    [self removeTemporaryAnnotations];
+    [self hideOriginalBrokenAnnotations];
+    [self addTemporaryAnnotations];
+}
+
+- (NSArray<PSPDFLinkAnnotation *> *)allLinkAnnotations {
+    NSMutableArray<PSPDFLinkAnnotation *> *annotations = [NSMutableArray array];
+    NSDictionary<NSNumber *, NSArray<PSPDFLinkAnnotation *> *> *annotationsDict = [self.document allAnnotationsOfType:PSPDFAnnotationTypeLink];
+    
+    for (NSArray<PSPDFLinkAnnotation *> *pageAnnotations in annotationsDict.allValues) {
+        [annotations addObjectsFromArray:pageAnnotations];
+    }
+    return [annotations copy];
+}
+
+- (NSArray<PSPDFLinkAnnotation *> *)allBrokenLinkAnnotations {
+    NSMutableArray<PSPDFLinkAnnotation *> *annotations = [NSMutableArray array];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(PSPDFLinkAnnotation *evaluatedObject, NSDictionary *bindings) {
+        NSString *invalidURLString = evaluatedObject.URLAction.invalidURLString;
+        return invalidURLString.length > 0 &&
+               [invalidURLString containsString:@"%5B"] &&
+               [invalidURLString containsString:@"%5D"] &&
+               [invalidURLString containsString:@"/videos/"];
+    }];
+    NSArray<PSPDFLinkAnnotation *> *filteredAnnotations = [[self allLinkAnnotations] filteredArrayUsingPredicate:predicate];
+    return filteredAnnotations;
+}
+
+- (void)removeTemporaryAnnotations {
+    NSArray<PSPDFLinkAnnotation *> *linkAnnotations = [self allLinkAnnotations];
+    if (linkAnnotations.count > 0) {
+        NSMutableArray<PSPDFAnnotation *> *tempAnnotations = [NSMutableArray array];
+        for (PSPDFAnnotation *annotation in linkAnnotations) {
+            if ([annotation.name hasSuffix:kTempAnnotationIdSuffix]) {
+                [tempAnnotations addObject:annotation];
+            }
+        }
+        if (tempAnnotations.count > 0) {
+            [self.document removeAnnotations:tempAnnotations options:nil];
+        }
+    }
+}
+
+- (void)hideOriginalBrokenAnnotations {
+    NSArray<PSPDFLinkAnnotation *> *linkAnnotations = [self allBrokenLinkAnnotations];
+    if (linkAnnotations.count > 0) {
+        for (PSPDFAnnotation *annotation in linkAnnotations) {
+            annotation.hidden = YES;
+            annotation.alpha = 0.0;
+        }
+    }
+}
+
+- (void)addTemporaryAnnotations {
+    NSArray<PSPDFLinkAnnotation *> *linkAnnotations = [self allBrokenLinkAnnotations];
+    NSMutableArray<PSPDFAnnotation *> *annotationsToAdd = [NSMutableArray array];
+    __block BOOL shouldRemoveCache = NO;
+    
+    for (PSPDFLinkAnnotation *annotation in linkAnnotations) {
+        NSString *originalURLString = annotation.URLAction.invalidURLString;
+        if (originalURLString == nil) {
+            continue;
+        }
+        NSURL *newURL = [self getVideoURLWithoutOptions:originalURLString];
+        PSPDFLinkAnnotation *newVideoAnnotation = [[PSPDFLinkAnnotation alloc] initWithURL:newURL];
+        newVideoAnnotation.boundingBox = annotation.boundingBox;
+        newVideoAnnotation.pageIndex = annotation.pageIndex;
+        newVideoAnnotation.name = [NSString stringWithFormat:@"%@%@", annotation.uuid, kTempAnnotationIdSuffix];
+        
+        [annotationsToAdd addObject:newVideoAnnotation];
+    }
+    if (annotationsToAdd.count > 0) {
+        shouldRemoveCache = YES;
+        [self.document addAnnotations:annotationsToAdd options:nil];
+    }
+    NSError *error = nil;
+    if ([self.document saveWithOptions:nil error:&error]) {
+        if (shouldRemoveCache) {
+            [PSPDFKitGlobal.sharedInstance.cache removeCacheForDocument:self.document];
+        }
+    } else {
+        NSLog(@"[ERROR] PSPDF Document not saved, error: %@", error.localizedDescription);
+    }
+}
+
+- (NSURL *)getVideoURLWithoutOptions:(NSString *)originalLink {
+    NSString *pattern = @"%5B.*?%5D";
+    NSError *error = nil;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+
+    NSString *urlStringWithoutOptions = @"";
+    if (!error) {
+        urlStringWithoutOptions = [regex stringByReplacingMatchesInString:originalLink options:0 range:NSMakeRange(0, [originalLink length]) withTemplate:@""];
+    } else {
+        NSLog(@"Error creating regex: %@", error.localizedDescription);
+    }
+    return [NSURL URLWithString:urlStringWithoutOptions];
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/Classes/TIPSPDFViewController.m
+++ b/Classes/TIPSPDFViewController.m
@@ -114,9 +114,10 @@ NSString *const kTempAnnotationIdSuffix = @"_tempPitAnn";
     NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(PSPDFLinkAnnotation *evaluatedObject, NSDictionary *bindings) {
         NSString *invalidURLString = evaluatedObject.URLAction.invalidURLString;
         return invalidURLString.length > 0 &&
-               [invalidURLString containsString:@"%5B"] &&
-               [invalidURLString containsString:@"%5D"] &&
-               [invalidURLString containsString:@"/videos/"];
+        [invalidURLString containsString:@"%5B"] &&
+        [invalidURLString containsString:@"%5D"] &&
+        [invalidURLString containsString:@"localhost/"] &&
+        [invalidURLString containsString:@"/videos/"];
     }];
     NSArray<PSPDFLinkAnnotation *> *filteredAnnotations = [[self allLinkAnnotations] filteredArrayUsingPredicate:predicate];
     return filteredAnnotations;

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 13.3.2
+version: 13.3.3
 description: PSPDFKit Annotate Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com


### PR DESCRIPTION
https://pitcher-ag.atlassian.net/browse/CORE-4926

### 📖 Description

This pull request addresses the issue of PDF embedded videos no longer working when building with iOS SDK 17. 

Background:
As with iOS SDK 17 Apple changed the URL/NSURL parsing from the obsolete RFC 1738/1808 standard to RFC 3986, the video link annotations URLs with format of type `pspdfkit://%5Bautostart:true%5Dlocalhost/../videos/1370129839191_55057208.mp4` are no longer properly parsed.

Workaround:
Dynamically replace those video link annotations using the `URLAction.invalidURLString` of a given broken annotation (stripping out all the display options between `[` and `]` chars in the original URLs). This is a dirty but functioning workaround (partially utilized the approach from the NG PDF Mustache dynamic annotation generation algorithm + some regex for the URL fix). 

Downside # 1: we lose the video link annotation options (like this `autostart:true`), but at least the video inside PDFs shows up and the user can play it.

Downside # 2: It selects the broken video link annotations by searching for: "%5B", "%5D" and "/videos/ in the `invalidURLString` of the link annotations.


### 📸 Recording - After the fix:

https://github.com/PitcherAG/Appcelerator-iOS/assets/2694531/b1be3787-163e-42f6-83c0-5da8ce8e6835

