### PR TITLE
fix: `autostart:true` config option for PDF embedded videos no longer working with iOS SDK 17; CORE-4926

### DIFF
--- a/Classes/TIPSPDFViewController.m
+++ b/Classes/TIPSPDFViewController.m
@@ -162,6 +162,7 @@ NSString *const kTempAnnotationIdSuffix = @"_tempPitAnn";
         PSPDFLinkAnnotation *newVideoAnnotation = [[PSPDFLinkAnnotation alloc] initWithURL:newURL];
         newVideoAnnotation.boundingBox = annotation.boundingBox;
         newVideoAnnotation.pageIndex = annotation.pageIndex;
+        newVideoAnnotation.autoplayEnabled = [originalURLString rangeOfString:@"autostart:true"].location != NSNotFound;
         newVideoAnnotation.name = [NSString stringWithFormat:@"%@%@", annotation.uuid, kTempAnnotationIdSuffix];
         
         [annotationsToAdd addObject:newVideoAnnotation];

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 13.3.3
+version: 13.3.4
 description: PSPDFKit Annotate Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com


### PR DESCRIPTION
https://pitcher-ag.atlassian.net/browse/CORE-4926

### 📖 Description

This pull request addresses the issue of unsupported `autostart:true` config option for PDF embedded videos when building with iOS SDK 17. 

Related PR: https://github.com/PitcherAG/Appcelerator-iOS/pull/5

### 📸 Recording - After the fix:

https://github.com/PitcherAG/Appcelerator-iOS/assets/2694531/cc845091-9423-4454-ba30-3047c7f413f7


